### PR TITLE
Ensure searches are stateless (I think)

### DIFF
--- a/extension/ts/adapters/book/webscrapers/bookFromSearch.ts
+++ b/extension/ts/adapters/book/webscrapers/bookFromSearch.ts
@@ -5,9 +5,11 @@ import {asyncCached} from "../bookCache";
 
 const SEARCH_URL = "https://www.librarything.com/catalog_bottom.php";
 
+const BASE_QUERY = {viewstyle: "4", collection: "-1"};
+
 const getSearchURL = (query: Record<string, string>) => {
 	const url = new URL(SEARCH_URL);
-	url.search = new URLSearchParams(query).toString();
+	url.search = new URLSearchParams({...query, ...BASE_QUERY}).toString();
 	return url.toString();
 };
 

--- a/extension/ts/extensions/author/authorPage/authorUI.ts
+++ b/extension/ts/extensions/author/authorPage/authorUI.ts
@@ -21,7 +21,7 @@ interface ButtonHandlers {
 const createTagLink = (tag: string) => {
 	const link = document.createElement("a");
 	link.innerText = tag;
-	link.href = `/catalog/?tag=${encodeURI(tag)}`;
+	link.href = `/catalog/&tag=${encodeURIComponent(tag)}`;
 	return link;
 };
 


### PR DESCRIPTION
When you go to the search and change the view or the collection, this gets saved in your cookie so next time you search, you have the same view.

This was breaking our "Pull" operation, as it doesn't do the $O(n)$ backup algorithm

Ten minutes in the network tab later, I have this