### PR TITLE
Handle runtime last error so console warnings go away

### DIFF
--- a/extension/ts/background/util/dispatchEvent.ts
+++ b/extension/ts/background/util/dispatchEvent.ts
@@ -1,17 +1,17 @@
 import {BackgroundEvent, BackgroundEventMessage} from "../../common/backgroundEvent";
 import Tab = chrome.tabs.Tab;
 
-const sendToTab = (event: BackgroundEventMessage) => (tab: Tab) => chrome.tabs.sendMessage(tab.id, event);
+const sendToTab = (event: BackgroundEventMessage) => (tab: Tab) => {
+	console.log(tab);
+	chrome.tabs.sendMessage(tab.id, event);
+};
 
 const sendToTabs = (event: BackgroundEventMessage) => (tabs: Tab[]) => tabs.forEach(sendToTab(event));
-
-const sendToBackgroundThreads = (event: BackgroundEventMessage) => chrome.runtime.sendMessage(event);
 
 const dispatchEvent = (event: BackgroundEvent) => {
 	const matches = chrome.runtime.getManifest().content_scripts.flatMap((contentScript) => contentScript.matches);
 	const message: BackgroundEventMessage = {kind: event, message: "background-event"};
 	chrome.tabs.query({url: matches}, sendToTabs(message));
-	return sendToBackgroundThreads(message);
 };
 
 export {dispatchEvent};

--- a/extension/ts/background/util/dispatchEvent.ts
+++ b/extension/ts/background/util/dispatchEvent.ts
@@ -1,10 +1,7 @@
 import {BackgroundEvent, BackgroundEventMessage} from "../../common/backgroundEvent";
 import Tab = chrome.tabs.Tab;
 
-const sendToTab = (event: BackgroundEventMessage) => (tab: Tab) => {
-	console.log(tab);
-	chrome.tabs.sendMessage(tab.id, event);
-};
+const sendToTab = (event: BackgroundEventMessage) => (tab: Tab) => chrome.tabs.sendMessage(tab.id, event);
 
 const sendToTabs = (event: BackgroundEventMessage) => (tabs: Tab[]) => tabs.forEach(sendToTab(event));
 

--- a/extension/ts/background/workers/authorize.ts
+++ b/extension/ts/background/workers/authorize.ts
@@ -15,8 +15,8 @@ const authorize = (interactive: AuthorizeParameters): Promise<AuthorizeResponse>
 					}
 					resolve(auth);
 				} else {
-					// TODO check runtime.lastError
-					reject(new WorkerError(WorkerErrorKind.Unknown, "Auth not granted"));
+					const {message} = chrome.runtime.lastError;
+					reject(new WorkerError(WorkerErrorKind.Unknown, message));
 				}
 			});
 		} else {

--- a/extension/ts/common/backgroundEvent.ts
+++ b/extension/ts/common/backgroundEvent.ts
@@ -10,22 +10,4 @@ interface BackgroundEventMessage extends Message {
 	kind: BackgroundEvent;
 }
 
-type Listener = () => void;
-
-const isBackgroundEventMessage = (message: Message): message is BackgroundEventMessage =>
-	message.message === "background-event";
-
-const onBackgroundEvent = (kind: BackgroundEvent, callback: Listener): void => {
-	listeners.get(kind).push(callback);
-};
-
-const listeners = new Map<BackgroundEvent, Listener[]>(Object.values(BackgroundEvent).map((kind) => [kind, []]));
-
-chrome.runtime.onMessage.addListener((message: Message) => {
-	if (isBackgroundEventMessage(message)) {
-		const {kind} = message;
-		listeners.get(kind).forEach((listener) => listener());
-	}
-});
-
-export {BackgroundEvent, onBackgroundEvent, BackgroundEventMessage};
+export {BackgroundEvent, BackgroundEventMessage};

--- a/extension/ts/main/extensions/util/onLogged.ts
+++ b/extension/ts/main/extensions/util/onLogged.ts
@@ -4,7 +4,8 @@ import {createIconButton} from "../../ui/button";
 import {isAuthorized} from "../author/util/isAuthorized";
 import {showToast, ToastType} from "../../ui/toast";
 import {loaderOverlaid} from "../../ui/loadingIndicator";
-import {BackgroundEvent, onBackgroundEvent} from "../../../common/backgroundEvent";
+import {BackgroundEvent} from "../../../common/backgroundEvent";
+import {onBackgroundEvent} from "../../util/onBackgroundEvent";
 
 const BAD_BROWSER_INFO_URL =
 	"https://github.com/braxtonhall/library-thing/blob/main/docs/librarian/authors.md#prerequisites";

--- a/extension/ts/main/util/onBackgroundEvent.ts
+++ b/extension/ts/main/util/onBackgroundEvent.ts
@@ -1,0 +1,22 @@
+import {Message} from "../../common/types";
+import {BackgroundEvent, BackgroundEventMessage} from "../../common/backgroundEvent";
+
+type Listener = () => void;
+
+const isBackgroundEventMessage = (message: Message): message is BackgroundEventMessage =>
+	message.message === "background-event";
+
+const onBackgroundEvent = (kind: BackgroundEvent, callback: Listener): void => {
+	listeners.get(kind).push(callback);
+};
+
+const listeners = new Map<BackgroundEvent, Listener[]>(Object.values(BackgroundEvent).map((kind) => [kind, []]));
+
+chrome.runtime.onMessage.addListener((message: Message) => {
+	if (isBackgroundEventMessage(message)) {
+		const {kind} = message;
+		listeners.get(kind).forEach((listener) => listener());
+	}
+});
+
+export {onBackgroundEvent};


### PR DESCRIPTION
resolves #157 

so turns out if you send a message from a background thread to a background thread, instead of the background thread receiving it, chrome just gets upset. so now only the foreground is capable of hearing messages from the background