### PR TITLE
Don't treat an empty tag input as a bad tag

### DIFF
--- a/extension/ts/content/extensions/tags/validation.ts
+++ b/extension/ts/content/extensions/tags/validation.ts
@@ -94,7 +94,11 @@ const getSecondaryAcceptance = (saveHandler: (options: GetTagsOptions) => Promis
 	);
 };
 
-const getTags = (tagInput: HTMLTextAreaElement) => tagInput.value.split(",").map((part) => part.trim());
+const getTags = (tagInput: HTMLTextAreaElement) =>
+	tagInput.value
+		.split(",")
+		.map((part) => part.trim())
+		.filter((tag) => !!tag);
 
 const getAncestorTags = async (tags: string[]): Promise<Set<string>> => {
 	const futureAncestors = tags.map((tag) => getAncestry(tag));


### PR DESCRIPTION
So if the tags input was completely empty, it would call it invalid, as in you have on bad tag (empty string)