### PR TITLE
Don't paste the barcode when pasting a book

### DIFF
--- a/extension/ts/content/entities/bookForm/data.ts
+++ b/extension/ts/content/entities/bookForm/data.ts
@@ -43,13 +43,13 @@ const getFormData = () =>
 		return saveData;
 	}, getFormMetadata());
 
-const insertFormData = (saveData: FormData) => {
+const insertFormData = (saveData: FormData, blackList: Set<string> = new Set()) => {
 	ensureRolesInputCount(saveData?.[FORM_META_DATA_KEY]?.[ROLES_INPUT_COUNT_KEY] ?? 0);
 	getFormElements().forEach((element: any) => {
 		// We can't change hidden elements because LibraryThing relies
 		// on hidden form inputs to send additional, form-specific metadata
 		// on save
-		if (element && element.id && element.type !== "hidden") {
+		if (element && element.id && element.type !== "hidden" && !blackList.has(element.id)) {
 			const {value, checked} = extractSaveDataFor(element, saveData);
 			if (element.value !== value || element.checked !== checked) {
 				element.value = value;

--- a/extension/ts/content/entities/bookForm/data.ts
+++ b/extension/ts/content/entities/bookForm/data.ts
@@ -1,4 +1,4 @@
-import {FormData} from "./types";
+import {FormAreaElement, FormData} from "./types";
 import {getFormElements} from "./util";
 import {ensureRolesInputCount, show} from "./ui";
 
@@ -7,6 +7,9 @@ const COLLECTIONS_KEY = "___collections_";
 
 const FORM_META_DATA_KEY = "___metadata_";
 const ROLES_INPUT_COUNT_KEY = "___roles-count_";
+
+// IDs of elements we don't want to copy/paste
+const ID_BLACKLIST = new Set(["item_inventory_barcode_1"]);
 
 const extractSaveDataFor = (targetElement: Element, formData: FormData) => {
 	if (targetElement.id.startsWith(COLLECTIONS_ID_PREFIX)) {
@@ -24,12 +27,15 @@ const getFormMetadata = (): FormData => ({[FORM_META_DATA_KEY]: {[ROLES_INPUT_CO
 // We subtract one to omit the main author, who is not part of the roles section
 const getRolesInputCount = (): number => document.querySelectorAll("input.bookEditInput.bookPersonName").length - 1;
 
+// We can't change hidden elements because LibraryThing relies
+// on hidden form inputs to send additional, form-specific metadata
+// on save
+const isFormDataElement = (element: FormAreaElement): boolean =>
+	element && element.id && element.type !== "hidden" && !ID_BLACKLIST.has(element.id);
+
 const getFormData = () =>
 	getFormElements().reduce((saveData: FormData, element: any) => {
-		// We can't change hidden elements because LibraryThing relies
-		// on hidden form inputs to send additional, form-specific metadata
-		// on save
-		if (element && element.id && element.type !== "hidden") {
+		if (isFormDataElement(element)) {
 			const {value, checked} = element;
 			if (element.id.startsWith(COLLECTIONS_ID_PREFIX)) {
 				const collections = saveData[COLLECTIONS_KEY] || {};
@@ -43,13 +49,10 @@ const getFormData = () =>
 		return saveData;
 	}, getFormMetadata());
 
-const insertFormData = (saveData: FormData, blackList: Set<string> = new Set()) => {
+const insertFormData = (saveData: FormData) => {
 	ensureRolesInputCount(saveData?.[FORM_META_DATA_KEY]?.[ROLES_INPUT_COUNT_KEY] ?? 0);
 	getFormElements().forEach((element: any) => {
-		// We can't change hidden elements because LibraryThing relies
-		// on hidden form inputs to send additional, form-specific metadata
-		// on save
-		if (element && element.id && element.type !== "hidden" && !blackList.has(element.id)) {
+		if (isFormDataElement(element)) {
 			const {value, checked} = extractSaveDataFor(element, saveData);
 			if (element.value !== value || element.checked !== checked) {
 				element.value = value;

--- a/extension/ts/content/extensions/copy.ts
+++ b/extension/ts/content/extensions/copy.ts
@@ -3,7 +3,6 @@ import {getFormData, insertFormData, onFormRender} from "../entities/bookForm";
 import {createIconButton} from "../../common/ui/button";
 
 const SAVE_DATA_KEY = "_save-data";
-const BARCODE_ID = "item_inventory_barcode_1";
 
 const onCopy = (event: Event) => {
 	event.preventDefault();
@@ -14,20 +13,11 @@ const onCopy = (event: Event) => {
 	);
 };
 
-const focusOn = (id: string) => {
-	const element = document.getElementById(id);
-	const top = window.scrollY; // capture the height before focus
-	element?.focus(); // focus will scroll us down
-	window.scroll({top}); // scroll us back up immediately
-	element?.scrollIntoView({behavior: "smooth"}); // smooth scroll down
-};
-
 const onPaste = (event: Event) => {
 	event.preventDefault();
 	try {
 		const saveData = JSON.parse(localStorage.getItem(SAVE_DATA_KEY) ?? "{}");
-		insertFormData(saveData, new Set([BARCODE_ID]));
-		focusOn(BARCODE_ID);
+		insertFormData(saveData);
 	} catch (error) {
 		console.error(error);
 		showToast("Something went wrong when trying to paste metadata :/", ToastType.ERROR);

--- a/extension/ts/content/extensions/copy.ts
+++ b/extension/ts/content/extensions/copy.ts
@@ -3,6 +3,7 @@ import {getFormData, insertFormData, onFormRender} from "../entities/bookForm";
 import {createIconButton} from "../../common/ui/button";
 
 const SAVE_DATA_KEY = "_save-data";
+const BARCODE_ID = "item_inventory_barcode_1";
 
 const onCopy = (event: Event) => {
 	event.preventDefault();
@@ -13,11 +14,20 @@ const onCopy = (event: Event) => {
 	);
 };
 
+const focusOn = (id: string) => {
+	const element = document.getElementById(id);
+	const top = window.scrollY; // capture the height before focus
+	element?.focus(); // focus will scroll us down
+	window.scroll({top}); // scroll us back up immediately
+	element?.scrollIntoView({behavior: "smooth"}); // smooth scroll down
+};
+
 const onPaste = (event: Event) => {
 	event.preventDefault();
 	try {
 		const saveData = JSON.parse(localStorage.getItem(SAVE_DATA_KEY) ?? "{}");
-		insertFormData(saveData);
+		insertFormData(saveData, new Set([BARCODE_ID]));
+		focusOn(BARCODE_ID);
 	} catch (error) {
 		console.error(error);
 		showToast("Something went wrong when trying to paste metadata :/", ToastType.ERROR);


### PR DESCRIPTION
toward #143 

Not an option, just the default behaviour.

Also scrolls down to the barcode, but not sure I like that. Like... do the catalogers even do that step at the same time?