### PR TITLE
1.3.0

### DIFF
--- a/docs/librarian/tag-index.md
+++ b/docs/librarian/tag-index.md
@@ -12,6 +12,7 @@ In order to support [author tagging](./authors.md), Better LibraryThing will sto
 1. Column `B` _must_ be the name of the author.
 1. Column `C` _must_ be the author tags.
 1. None of these columns can be hidden, however the sheet itself may be hidden.
+1. Additionally, there must be _another_ sheet in The Tag Index labelled **LOOKUP**. This sheet should be hidden.
 
 Example:
 

--- a/docs/releases/1.3.0.md
+++ b/docs/releases/1.3.0.md
@@ -1,0 +1,15 @@
+# Release Notes
+
+## New Features
+- Nested tags! If you add a tag like "1st-3rd grade", then "children's" will automatically get added to the book when you save.
+- Tag validation! You'll be warned if you try to save a tag that's not in the Tag Index.
+- Changing a book title's sorting will now show you what the book will be sorted as directly on the form.
+- Author tags now support autocompletion.
+- What's new? There's a good chance you're seeing this page because the extension suggested you check it out. That's a new feature!
+
+## Changes
+- PDF and summary searches will now stop searching after ten seconds.
+- Logging out of your Google account will now properly update the page you're on to show you are logged out.
+- The LibraryThing banner will now also be greyed out if you're not logged in to a Google account, as you would be missing out on the new safety features.
+- Form resize saving now also applies to the author page.
+- Minor behind the scenes improvements for the developers.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Better LibraryThing",
-	"version": "1.2.2",
+	"version": "1.3.0",
 	"manifest_version": 3,
 	"description": "Makes LibraryThing BETTER",
 	"icons": {

--- a/extension/ts/content/extensions/author/authorPage/util.ts
+++ b/extension/ts/content/extensions/author/authorPage/util.ts
@@ -11,7 +11,7 @@ const getAuthorInfo = () => {
 
 const getTags = async () => {
 	const author = await Author.getAuthor(getAuthorInfo().uuid);
-	author && insertTags(author.tags);
+	insertTags(author?.tags ?? []);
 };
 
 const authorTagsFromBooksWhere = (books: BookRecord[], where: (book: BookRecord) => boolean) =>


### PR DESCRIPTION
- [x] Bug fixes
- [x] Bump version
- [x] Add documentation

If an author didn't have an entry in the Tag Index, their tags just stayed as `Unknown`.