### PR TITLE
Update manifest and webpack for webstore

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
 	"name": "Better LibraryThing",
 	"version": "1.3.2",
 	"manifest_version": 3,
-	"description": "Makes LibraryThing BETTER",
+	"description": "Improves the LibraryThing cataloging experience",
 	"icons": {
 		"16": "img/icon16.png",
 		"48": "img/icon48.png",
@@ -22,7 +22,6 @@
 	"content_security_policy": {},
 	"host_permissions": [
 		"https://*.librarything.com/*",
-		"https://*.b-ok.cc/*",
 		"https://*.libgen.is/*",
 		"https://*.archive.org/*",
 		"https://*.goodreads.com/*",
@@ -32,7 +31,7 @@
 	"background": {
 		"service_worker": "js/background.js"
 	},
-	"permissions": ["tabs", "storage", "identity"],
+	"permissions": ["storage", "identity"],
 	"oauth2": {
 		"client_id": "1065384085182-m6bva575fe1bdvu9r80s811trepat999.apps.googleusercontent.com",
 		"scopes": [

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -85,4 +85,7 @@ module.exports = (_env: any, options: WebpackOptionsNormalized): Configuration =
 			]
 		}),
 	],
+	optimization: {
+		minimize: false
+	},
 });


### PR DESCRIPTION
This _should_ be all the changes we need for this to go live on the webstore again.

I'll be honest I have not tested it, but at MOST we'll need to remove the `key` field from `manifest.json` next time we ship.