### PR TITLE
Don't create a warning when users try to save a book on Firefox

### DIFF
--- a/src/ts/content/entities/bookForm/render.ts
+++ b/src/ts/content/entities/bookForm/render.ts
@@ -1,13 +1,14 @@
 import {FormAreaElement} from "./types";
 import {formExists, getForm, getFormElements} from "./util";
-import {createOnSave, OffSave, OnSave} from "./save";
+import {createOnSave, OffSave, OnConfirm, OnSave} from "./save";
 
 type ForEachFormElement = (callback: (element: FormAreaElement) => void) => void;
 type FormRenderListener = (
 	form: HTMLElement,
 	forEachElement: ForEachFormElement,
 	onSave: OnSave,
-	offSave: OffSave
+	offSave: OffSave,
+	onConfirm: OnConfirm
 ) => void;
 
 const FORM_RENDER_EVENT = "library-thing-form-rendered";
@@ -18,10 +19,10 @@ const forEachFormElement: ForEachFormElement = (callback: (element: FormAreaElem
 
 const listeners = new Map<FormRenderListener, () => void>();
 // kinda gross but i don't have a better idea without a bIG refactor
-let save: {onSave: OnSave; offSave: OffSave};
+let save: {onSave: OnSave; offSave: OffSave; onConfirm: OnConfirm};
 
 const encloseCallbackArguments = (callback: FormRenderListener) => () =>
-	callback(getForm(document), forEachFormElement, save.onSave, save.offSave);
+	callback(getForm(document), forEachFormElement, save.onSave, save.offSave, save.onConfirm);
 
 const onFormRender = (callback: FormRenderListener): void => {
 	const listener = encloseCallbackArguments(callback);

--- a/src/ts/content/entities/bookForm/save.ts
+++ b/src/ts/content/entities/bookForm/save.ts
@@ -1,35 +1,51 @@
 type OnSave = (callback: OnSaveListener) => void;
 type OffSave = OnSave;
+type OnConfirm = (callback: OnConfirmedListener) => void;
 type OnSaveListener = () => Promise<boolean>;
+type OnConfirmedListener = () => void;
 
-const maybeClick = (realButton: HTMLElement, clickedButton: HTMLElement, listeners: Set<OnSaveListener>) => async () =>
-	Array.from(listeners.values())
-		.reduce((promise, listener) => promise.then((result) => result && listener()), Promise.resolve(true))
-		.then((result) => {
-			if (result) {
-				clickedButton.style.display = "none";
-				realButton.dispatchEvent(new Event("click"));
-			}
-		});
+const maybeClick =
+	(
+		realButton: HTMLElement,
+		clickedButton: HTMLElement,
+		listeners: Set<OnSaveListener>,
+		confirmListeners: Set<OnConfirmedListener>
+	) =>
+	async () =>
+		Array.from(listeners.values())
+			.reduce((promise, listener) => promise.then((result) => result && listener()), Promise.resolve(true))
+			.then((result) => {
+				if (result) {
+					clickedButton.style.display = "none";
+					confirmListeners.forEach((callback) => callback());
+					realButton.dispatchEvent(new Event("click"));
+				}
+			});
 
-const replaceButton = (button: HTMLElement, listeners: Set<OnSaveListener>) => {
+const replaceButton = (
+	button: HTMLElement,
+	saveListeners: Set<OnSaveListener>,
+	confirmListeners: Set<OnConfirmedListener>
+) => {
 	const td = document.createElement("td");
 	td.className = button.className;
 	td.style.cssText = button.style.cssText;
 	td.innerHTML = button.innerHTML;
-	td.addEventListener("click", maybeClick(button, td, listeners));
+	td.addEventListener("click", maybeClick(button, td, saveListeners, confirmListeners));
 	button.style.display = "none";
 	button.insertAdjacentElement("beforebegin", td);
 };
 
-const createOnSave = (): {onSave: OnSave; offSave: OffSave} => {
+const createOnSave = (): {onSave: OnSave; offSave: OffSave; onConfirm: OnConfirm} => {
 	const listeners: Set<OnSaveListener> = new Set<OnSaveListener>();
-	replaceButton(document.getElementById("book_editTabTextSave1"), listeners);
-	replaceButton(document.getElementById("book_editTabTextSave2"), listeners);
+	const confirmListeners: Set<OnConfirmedListener> = new Set<OnConfirmedListener>();
+	replaceButton(document.getElementById("book_editTabTextSave1"), listeners, confirmListeners);
+	replaceButton(document.getElementById("book_editTabTextSave2"), listeners, confirmListeners);
 	const onSave = (callback: OnSaveListener) => listeners.add(callback);
 	const offSave = (callback: OnSaveListener) => listeners.delete(callback);
-	return {onSave, offSave};
+	const onConfirm = (callback: OnConfirmedListener) => confirmListeners.add(callback);
+	return {onSave, offSave, onConfirm};
 };
 
-export type {OnSave, OffSave};
+export type {OnSave, OffSave, OnConfirm};
 export {createOnSave};

--- a/src/ts/content/extensions/warning.ts
+++ b/src/ts/content/extensions/warning.ts
@@ -25,7 +25,8 @@ const onExit = (event: Event) => {
 const addUnloadListener = () => window.addEventListener("beforeunload", onExit);
 
 onceFormRender(addUnloadListener);
-onFormRender(() => {
+onFormRender((form, forEachElement, onSave, offSave, onConfirm) => {
 	undoEdits();
 	addUndoEditListener();
+	onConfirm(undoEdits);
 });


### PR DESCRIPTION
prettier made this PR look way bigger than it is

was a problem on firefox that "undoEdits" was called after the redirect was initiated. fixed