### PR TITLE
Clear Modals by clicking them instead of deleting all overlays

### DIFF
--- a/src/ts/common/ui/modal.ts
+++ b/src/ts/common/ui/modal.ts
@@ -1,6 +1,6 @@
 import "../../../sass/modal.sass";
 
-import {createOverlay, clearOverlays} from "./overlay";
+import {createOverlay} from "./overlay";
 import {UIColour} from "./colour";
 
 interface ModalElement {
@@ -37,6 +37,8 @@ const MODAL_BUTTON_CLASS_NAME = "better-library-thing-modal-button";
 const MODAL_INPUT_CLASS_NAME = "better-library-thing-modal-input";
 const MODAL_INPUT_CONTAINER_CLASS_NAME = "better-library-thing-modal-input-container";
 const MODAL_ELEMENT_CONTAINER_CLASS_NAME = "better-library-thing-modal-element-container";
+
+const activeOverlays = new Set<HTMLElement>();
 
 const createWithClass = <K extends keyof HTMLElementTagNameMap>(
 	tag: K,
@@ -96,12 +98,18 @@ const addOnClick = (element: HTMLElement, exit: () => void, onClick?: () => Prom
 	element.addEventListener("click", () => callback().finally(exit));
 };
 
+const dismissModals = (): void => activeOverlays.forEach((modal) => modal.dispatchEvent(new Event("click")));
+
 const createModal = ({text, subText, elements, onCancel, colour}: ModalOptions): void => {
-	const exit = clearOverlays;
+	const exit = () => {
+		activeOverlays.delete(overlay);
+		overlay.remove();
+	};
 
 	const overlay = createOverlay();
 	overlay.classList.add("modal");
 	addOnClick(overlay, exit, onCancel);
+	activeOverlays.add(overlay);
 
 	const modal = createWithClass("div", `${MODAL_CLASS_NAME} ${colour}`);
 	modal.addEventListener("click", (event) => event.stopPropagation());
@@ -117,4 +125,4 @@ const createModal = ({text, subText, elements, onCancel, colour}: ModalOptions):
 	document.body.appendChild(overlay);
 };
 
-export {createModal};
+export {createModal, dismissModals};

--- a/src/ts/common/ui/overlay.ts
+++ b/src/ts/common/ui/overlay.ts
@@ -8,9 +8,4 @@ const createOverlay = () => {
 	return element;
 };
 
-const clearOverlays = () => {
-	const overlays = document.getElementsByClassName(OVERLAY_CLASS_NAME);
-	Array.from(overlays).forEach((overlay) => overlay.remove());
-};
-
-export {createOverlay, clearOverlays};
+export {createOverlay};

--- a/src/ts/content/extensions/enforceTagIndexAccess.ts
+++ b/src/ts/content/extensions/enforceTagIndexAccess.ts
@@ -1,8 +1,7 @@
 import config, {ConfigKey} from "../../common/entities/config";
-import {createModal} from "../../common/ui/modal";
+import {createModal, dismissModals} from "../../common/ui/modal";
 import {UIColour} from "../../common/ui/colour";
 import {onLogged} from "./util/onLogged";
-import {clearOverlays} from "../../common/ui/overlay";
 import {invokeWorker} from "../../common/workers/invoker";
 import {WorkerKind} from "../../common/workers/types";
 import {onBackgroundEvent} from "../util/onBackgroundEvent";
@@ -11,7 +10,7 @@ import {BackgroundEvent} from "../../common/backgroundEvent";
 let canAccessTagIndex = true; // default to true to reduce likelihood of pop in (very unlikely)
 
 const enforceTagIndexAccess = async () => {
-	clearOverlays();
+	dismissModals();
 	if (await config.get(ConfigKey.EnforceTagIndexAccess)) {
 		const createWarningModal = async () => {
 			canAccessTagIndex === false &&


### PR DESCRIPTION
1. It didn't make much sense to be clearing all overlays, when that would clear loaders as well. So instead we clear specifically modals. We just click them, and let the default remove implementation deal with it. resolves #248 
2. Now in my local testing, the enforcement is working again? Only I _swear_ it was working before I uploaded it to the web store, so maybe the race condition is environment dependent???? Anyway, resolves #250 
   - Edit: no just checked out main and it's still borked locally. No clue when I slipped the regression in
   - Edit 2: did a proper build and the bug is NOT fixed. seems like it works on a `yarn watch` but doesn't on a `yarn build`. deffo a race condition
   - Edit 3: No it turns out when I did a yarn build and then reloaded the extension in the browser, it was somehow using the webstore one? I removed the extension completely and then reloaded it, and everything is working as intended