### PR TITLE
Rethink the Modal API

### DIFF
--- a/src/sass/modal.sass
+++ b/src/sass/modal.sass
@@ -3,7 +3,11 @@
 $modal-background-colour: colours.$white
 
 .better-library-thing-overlay.modal
-	cursor: pointer
+	&:not(.exitable)
+		cursor: unset
+
+	.exitable
+		cursor: pointer
 
 	.better-library-thing-modal
 		text-align: center

--- a/src/ts/content/extensions/enforceTagIndexAccess.ts
+++ b/src/ts/content/extensions/enforceTagIndexAccess.ts
@@ -9,10 +9,10 @@ import {BackgroundEvent} from "../../common/backgroundEvent";
 
 let canAccessTagIndex = true; // default to true to reduce likelihood of pop in (very unlikely)
 
-const ENFORCEMENT_MODAL_ID = "enforce-tag-index-modal";
+const ENFORCEMENT_MODAL_TAG = "enforce-tag-index-modal";
 
 const enforceTagIndexAccess = async () => {
-	dismissModals(ENFORCEMENT_MODAL_ID);
+	dismissModals(ENFORCEMENT_MODAL_TAG);
 	if (await config.get(ConfigKey.EnforceTagIndexAccess)) {
 		const createWarningModal = async () => {
 			canAccessTagIndex === false &&
@@ -34,7 +34,7 @@ const enforceTagIndexAccess = async () => {
 						},
 					],
 					colour: UIColour.PURPLE,
-					id: ENFORCEMENT_MODAL_ID,
+					tag: ENFORCEMENT_MODAL_TAG,
 					exitable: false,
 				});
 		};

--- a/src/ts/content/extensions/enforceTagIndexAccess.ts
+++ b/src/ts/content/extensions/enforceTagIndexAccess.ts
@@ -9,8 +9,10 @@ import {BackgroundEvent} from "../../common/backgroundEvent";
 
 let canAccessTagIndex = true; // default to true to reduce likelihood of pop in (very unlikely)
 
+const ENFORCEMENT_MODAL_ID = "enforce-tag-index-modal";
+
 const enforceTagIndexAccess = async () => {
-	dismissModals();
+	dismissModals(ENFORCEMENT_MODAL_ID);
 	if (await config.get(ConfigKey.EnforceTagIndexAccess)) {
 		const createWarningModal = async () => {
 			canAccessTagIndex === false &&
@@ -32,7 +34,8 @@ const enforceTagIndexAccess = async () => {
 						},
 					],
 					colour: UIColour.PURPLE,
-					onCancel: createWarningModal,
+					id: ENFORCEMENT_MODAL_ID,
+					exitable: false,
 				});
 		};
 		return createWarningModal();


### PR DESCRIPTION
Still thinking about the Modal API. 

1. I didn't like that you might dismiss unrelated Modals.
2. I didn't like that "unexitable" modals were implemented via exiting and reopening, as that is confusing to the user, and confusing to implement as a client code.
   - The reason I removed `exitable` in the first place was because I wanted to ensure that the `onCancel` always got called, but now I've restored the `onCancel` even if cancelled by `dismissModals` while `exitable` is still present.

Very open to more rewrites to this. The code is all wacky/terrible to read, but I think this is the strongest version of the API so far.