### PR TITLE
Display versions of extension in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,15 @@ A browser extension to improve the [LibraryThing](https://www.librarything.com/)
 [link-chrome]: https://chrome.google.com/webstore/detail/better-librarything/hbnlneckiahefebnpdhgpohonfkkcaln "Version published on Chrome Web Store"
 [link-firefox]: https://addons.mozilla.org/en-US/firefox/addon/betterlibrarything/ "Version published on Mozilla Add-ons"
 
-[<img src="https://raw.githubusercontent.com/alrra/browser-logos/90fdf03c/src/chrome/chrome.svg" width="48" alt="Chrome" valign="middle">][link-chrome] also compatible with [<img src="https://raw.githubusercontent.com/alrra/browser-logos/90fdf03c/src/edge/edge.svg" width="24" alt="Edge" valign="middle">][link-chrome] [<img src="https://raw.githubusercontent.com/alrra/browser-logos/90fdf03c/src/opera/opera.svg" width="24" alt="Opera" valign="middle">][link-chrome] [<img src="https://raw.githubusercontent.com/alrra/browser-logos/90fdf03c/src/brave/brave.svg" width="24" alt="Brave" valign="middle">][link-chrome]
+[<img src="https://raw.githubusercontent.com/alrra/browser-logos/90fdf03c/src/chrome/chrome.svg" width="48" alt="Chrome" valign="middle">][link-chrome]
+[<img valign="middle" src="https://img.shields.io/chrome-web-store/v/hbnlneckiahefebnpdhgpohonfkkcaln.svg?label=%20">][link-chrome]
+also compatible with
+[<img src="https://raw.githubusercontent.com/alrra/browser-logos/90fdf03c/src/edge/edge.svg" width="24" alt="Edge" valign="middle">][link-chrome]
+[<img src="https://raw.githubusercontent.com/alrra/browser-logos/90fdf03c/src/opera/opera.svg" width="24" alt="Opera" valign="middle">][link-chrome]
+[<img src="https://raw.githubusercontent.com/alrra/browser-logos/90fdf03c/src/brave/brave.svg" width="24" alt="Brave" valign="middle">][link-chrome]
 
 [<img src="https://raw.githubusercontent.com/alrra/browser-logos/90fdf03c/src/firefox/firefox.svg" width="48" alt="Firefox" valign="middle">][link-firefox]
+[<img valign="middle" src="https://img.shields.io/amo/v/betterlibrarything.svg?label=%20">][link-firefox]
 
 ## Features
 

--- a/index.html
+++ b/index.html
@@ -36,19 +36,7 @@
 			h4 {
 				font: 20px "Montserrat", sans-serif;
 			}
-			img[src*="/browser-logos/"] {
-				display: unset;
-				margin-left: unset;
-				margin-bottom: unset;
-				filter: unset;
-			}
-			img[src$="/vbl.png"] {
-				display: unset;
-				margin-left: unset;
-				margin-bottom: unset;
-				filter: unset;
-			}
-			img {
+			#main > img {
 				margin-bottom: 2em;
 				max-width: 90vw;
 				display: block;


### PR DESCRIPTION
Because why not
<img width="357" alt="image" src="https://user-images.githubusercontent.com/35436247/212119566-ed60b270-9e90-43c3-a7b2-2bb6b517abdd.png">
