### PR TITLE
Version the Tag Index Index formatting

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/src/ts/content/adapters/sheets/index.ts
+++ b/src/ts/content/adapters/sheets/index.ts
@@ -2,7 +2,7 @@ import {googleFetch} from "../../services/google/googleFetch";
 
 const BASE_URL = "https://sheets.googleapis.com/v4/spreadsheets";
 
-type Range = `${string}!${string}` | `${string}!${string}:${string}`;
+type Range = string;
 type Values = string[][];
 
 interface ValueRange {
@@ -44,6 +44,9 @@ const readRanges = async (spreadsheetId: string, ranges: Range[]): Promise<Value
 	return response?.valueRanges ?? null;
 };
 
+const readRange = (spreadsheetId: string, range: Range): Promise<ValueRange | null> =>
+	readRanges(spreadsheetId, [range]).then((response) => response?.[0] ?? null);
+
 const appendRowToSheet = async (spreadsheetId: string, range: string, values: Values): Promise<ValueRange | null> => {
 	const options: RequestInit = {
 		method: "POST",
@@ -81,7 +84,15 @@ const updateRowInSheet = async (spreadsheetId: string, range: string, values: Va
 	return response?.updatedData ?? null;
 };
 
-const createRange = (sheet: string, from: string, to?: string): Range => `${sheet}!${from}${to ? `:${to}` : ""}`;
+const createRange = (sheet: string, from?: string, to?: string): Range => {
+	if (to) {
+		return `${sheet}!${from}:${to}`;
+	} else if (from) {
+		return `${sheet}!${from}`;
+	} else {
+		return sheet;
+	}
+};
 
 export type {ValueRange, Range, Values};
-export default {readRanges, appendRowToSheet, updateRowInSheet, createRange};
+export default {readRange, readRanges, appendRowToSheet, updateRowInSheet, createRange};

--- a/src/ts/content/adapters/tags/getTagSheets/formats/impl/aaliyah.ts
+++ b/src/ts/content/adapters/tags/getTagSheets/formats/impl/aaliyah.ts
@@ -1,0 +1,87 @@
+import Sheets, {Range, ValueRange, Values} from "../../../../sheets";
+import {RawTagSheet, TagMapper, TagSheetDescriptor, WarnedTag} from "../../../types";
+import {FormatStrategy} from "../index";
+import {getSheetId} from "../../../../../../common/entities/spreadsheet";
+import {incrementColumnBy} from "../../../../sheets/util";
+
+/**
+ * RE: Version "aaliyah"
+ * The Meta Tag Sheet stores information about where tags are in the spreadsheet
+ * Each row is of the form
+ *   | SHEET | TOP_LEFT | WIDTH | CW_COL? | MAPPER? | AS? |
+ * where
+ * SHEET    is the name of a sheet in the spreadsheet where tags live
+ * TOP_LEFT is the top left most cell in the sheet the contains a tag
+ * WIDTH    is how many columns contain tags
+ * MAPPER   is how tags should be mapped to after being consumed by BLT
+ *           mapped tags only exist dynamically in BLT
+ * AS       is how the (possibly artificial) sheet should be named by BLT
+ *
+ * Example:
+ *   | Identity | A2 | 2 |
+ * In the sheet "Identity" there is a table of width 2 storing tags.
+ *    The first tag in this table is at A2
+ */
+
+const rowIsRange = ([, topLeft, width]: string[]): boolean =>
+	topLeft && width && /^[A-Z]+[0-9]+$/.test(topLeft) && /^[0-9]+$/.test(width);
+
+const rowToSheetDescriptor = ([sheet, topLeft, width, cwColumn, userMapper, as]: string[]): TagSheetDescriptor => {
+	// `left` is a column, for example "B"
+	const left = topLeft.match(/^[A-Z]+/)[0];
+	// `top` is a row, for example "4"
+	const top = topLeft.match(/[0-9]+$/)[0];
+	// `right` is the right most column with tags if there are `width` columns of tags
+	// for example, `left` = "B", `width` = 2, `right` = "C"
+	const right = incrementColumnBy(left, Number(width) - 1);
+	const range: Range = `${sheet}!${topLeft}:${right}`;
+	const cwRange: Range = cwColumn ? `${sheet}!${cwColumn}${top}:${cwColumn}` : undefined;
+	const mapper: TagMapper = (userMapper ?? "").includes("$TAG") ? (userMapper as TagMapper) : "$TAG";
+	return {range, mapper, cwRange, height: Number(width), name: as ?? sheet};
+};
+
+const getSheetDescriptors = (metaSheet: Values): TagSheetDescriptor[] =>
+	metaSheet?.filter(rowIsRange).map(rowToSheetDescriptor) ?? [];
+
+const extractRanges = (ranges: TagSheetDescriptor[]): Set<Range> =>
+	ranges.reduce(
+		(acc, {cwRange, range}) => (cwRange ? acc.add(cwRange).add(range) : acc.add(range)),
+		new Set<Range>()
+	);
+
+const nameResponses = (ranges: Range[], response: ValueRange[] | null): Map<Range, Values> => {
+	const groupedResponses = new Map();
+	response?.forEach((valueRange, index) => groupedResponses.set(ranges[index], valueRange?.values));
+	return groupedResponses;
+};
+
+const annotateWithContentWarnings = (tags: string[][], contentWarnings: Values | undefined): WarnedTag[][] =>
+	tags.map((row, rowIndex) =>
+		row.map((cell) => ({tag: cell.trim(), warning: !!contentWarnings?.values?.[rowIndex]?.[0]}))
+	);
+
+const toTagSheet =
+	(namedResponses: Map<Range, Values>) =>
+	(descriptor: TagSheetDescriptor): RawTagSheet => {
+		const tags = namedResponses.get(descriptor.range);
+		const mappedTags = mapTags(tags, descriptor.mapper);
+		const contentWarnings = namedResponses.get(descriptor.cwRange);
+		const values = annotateWithContentWarnings(mappedTags, contentWarnings);
+		return {...descriptor, values};
+	};
+
+const mapTags = (values: Values | undefined, mapper: TagMapper): string[][] => {
+	return values?.map((row) => row.map((value) => mapper.replaceAll("$TAG", value))) ?? [];
+};
+
+const aaliyah: FormatStrategy = async (metaSheet: Values): Promise<RawTagSheet[]> => {
+	const mappedRanges = getSheetDescriptors(metaSheet);
+	const ranges = [...extractRanges(mappedRanges)]; // We might have duplicate ranges, so we use a set when extracting
+	const response = await Sheets.readRanges(await getSheetId(), ranges);
+	const namedResponses = nameResponses(ranges, response);
+	return mappedRanges.map(toTagSheet(namedResponses));
+};
+
+// TODO if aaliyah ever gets deprecated, it should also warn the user somehow that the Tag Index is out of date
+
+export {aaliyah};

--- a/src/ts/content/adapters/tags/getTagSheets/formats/impl/zhane.ts
+++ b/src/ts/content/adapters/tags/getTagSheets/formats/impl/zhane.ts
@@ -1,0 +1,19 @@
+import {FormatStrategy} from "../index";
+import {showToast, ToastType} from "../../../../../../common/ui/toast";
+
+/**
+ * This represents a format that is being used by the Tag Index, but it not
+ * yet recognized by Better LibraryThing.
+ *
+ * This could happen if the extension is out of date.
+ */
+
+const WARNING =
+	"hey! it seems like your installation of Better LibraryThing is a little out of date.\nclick here for update information!";
+
+const zhane: FormatStrategy = async () => {
+	showToast(WARNING, ToastType.WARNING, () => window.open("https://betterlibrarything.com/"));
+	return [];
+};
+
+export {zhane};

--- a/src/ts/content/adapters/tags/getTagSheets/formats/impl/zhane.ts
+++ b/src/ts/content/adapters/tags/getTagSheets/formats/impl/zhane.ts
@@ -9,10 +9,10 @@ import {showToast, ToastType} from "../../../../../../common/ui/toast";
  */
 
 const WARNING =
-	"hey! it seems like your installation of Better LibraryThing is a little out of date.\nclick here for update information!";
+	"hey! it seems like your installation of Better LibraryThing is really out of date!\nif you'd like to keep using it, click here for update information!";
 
 const zhane: FormatStrategy = async () => {
-	showToast(WARNING, ToastType.WARNING, () => window.open("https://betterlibrarything.com/"));
+	showToast(WARNING, ToastType.ERROR, () => window.open("https://betterlibrarything.com/"));
 	return [];
 };
 

--- a/src/ts/content/adapters/tags/getTagSheets/formats/index.ts
+++ b/src/ts/content/adapters/tags/getTagSheets/formats/index.ts
@@ -24,9 +24,12 @@ const toFormatVersion = (userFormatVersion: string): FormatVersion =>
 
 const getFormatVersion = (values: Values): FormatVersion => {
 	const firstRow = values[0] ?? [];
-	const formatKeywordIndex = firstRow.findIndex((cell) => cell.trim().toLowerCase() === FormatKeyword.FORMAT);
-	const userFormatVersion = firstRow[formatKeywordIndex + 1]?.trim()?.toLowerCase();
-	return toFormatVersion(userFormatVersion ?? DEFAULT_FORMAT_VERSION);
+	const [hashFormat, rawUserFormat] = firstRow;
+	if (hashFormat?.trim()?.toLowerCase() === FormatKeyword.FORMAT) {
+		return toFormatVersion(rawUserFormat?.trim()?.toLowerCase() ?? DEFAULT_FORMAT_VERSION);
+	} else {
+		return DEFAULT_FORMAT_VERSION;
+	}
 };
 
 const getFormatStrategy = (values: Values): FormatStrategy => getSheetsTagsStrategies[getFormatVersion(values)];

--- a/src/ts/content/adapters/tags/getTagSheets/formats/index.ts
+++ b/src/ts/content/adapters/tags/getTagSheets/formats/index.ts
@@ -1,0 +1,35 @@
+import {FormatKeyword} from "../keywords";
+import {Values} from "../../../sheets";
+import {RawTagSheet} from "../../types";
+import {aaliyah} from "./impl/aaliyah";
+import {zhane} from "./impl/zhane";
+
+type FormatStrategy = (metaTagSheet: Values) => Promise<RawTagSheet[]>;
+
+enum FormatVersion {
+	AALIYAH = "aaliyah",
+	ZHANE = "zhane",
+}
+
+const DEFAULT_FORMAT_VERSION = FormatVersion.AALIYAH;
+const UNKNOWN_FORMAT_VERSION = FormatVersion.ZHANE;
+
+const getSheetsTagsStrategies: {[key in FormatVersion]: FormatStrategy} = {
+	[FormatVersion.AALIYAH]: aaliyah,
+	[FormatVersion.ZHANE]: zhane,
+};
+
+const toFormatVersion = (userFormatVersion: string): FormatVersion =>
+	Object.values(FormatVersion).find((version) => version === userFormatVersion) ?? UNKNOWN_FORMAT_VERSION;
+
+const getFormatVersion = (values: Values): FormatVersion => {
+	const firstRow = values[0] ?? [];
+	const formatKeywordIndex = firstRow.findIndex((cell) => cell.trim().toLowerCase() === FormatKeyword.FORMAT);
+	const userFormatVersion = firstRow[formatKeywordIndex + 1]?.trim()?.toLowerCase();
+	return toFormatVersion(userFormatVersion ?? DEFAULT_FORMAT_VERSION);
+};
+
+const getFormatStrategy = (values: Values): FormatStrategy => getSheetsTagsStrategies[getFormatVersion(values)];
+
+export type {FormatStrategy};
+export {getFormatStrategy};

--- a/src/ts/content/adapters/tags/getTagSheets/index.ts
+++ b/src/ts/content/adapters/tags/getTagSheets/index.ts
@@ -1,0 +1,28 @@
+import {RawTagSheet} from "../types";
+import Sheets, {Values} from "../../sheets";
+import {getSheetId} from "../../../../common/entities/spreadsheet";
+import {getFormatStrategy} from "./formats";
+
+/**
+ * The Meta Tag Sheet stores information about where tags are in the spreadsheet
+ * The format of the Meta Tag Sheet is dependent on the formatting version
+ * Format version is decided by the use of the #format keyword in the first row
+ * of The Meta Tag Sheet.
+ *
+ * #format will always be in the first row of the Meta Tag Sheet. This can never change.
+ */
+const META_TAG_SHEET = "Tag Index Index";
+
+const getMetaTagSheet = async (): Promise<Values> => {
+	const range = Sheets.createRange(META_TAG_SHEET);
+	const response = await Sheets.readRange(await getSheetId(), range);
+	return response?.values ?? [];
+};
+
+const getSheetsTags = async (): Promise<RawTagSheet[]> => {
+	const metaSheet = await getMetaTagSheet();
+	const formatStrategy = getFormatStrategy(metaSheet);
+	return formatStrategy(metaSheet);
+};
+
+export {getSheetsTags};

--- a/src/ts/content/adapters/tags/getTagSheets/keywords.ts
+++ b/src/ts/content/adapters/tags/getTagSheets/keywords.ts
@@ -1,0 +1,5 @@
+enum FormatKeyword {
+	FORMAT = "#format",
+}
+
+export {FormatKeyword};

--- a/src/ts/content/adapters/tags/getTags.ts
+++ b/src/ts/content/adapters/tags/getTags.ts
@@ -1,90 +1,9 @@
 import {makeCache} from "../../../common/util/cache";
-import {TagSearchOptions, WarnedTag, TagSheetDescriptor, TagMapper, RawTagSheet, Tags} from "./types";
-import Sheets, {Range, ValueRange, Values} from "../sheets";
+import {TagSearchOptions, Tags} from "./types";
 import {parseTags} from "./parseTags";
-import {incrementColumnBy} from "../sheets/util";
-import {getSheetId} from "../../../common/entities/spreadsheet";
-
-const META_TAG_SHEET = "Tag Index Index";
-/**
- * The Meta Tag Sheet stores information about where tags are in the spreadsheet
- * Each row is of the form
- *   | SHEET | TOP_LEFT | WIDTH | CW_COL? | MAPPER? | AS? |
- * where
- * SHEET    is the name of a sheet in the spreadsheet where tags live
- * TOP_LEFT is the top left most cell in the sheet the contains a tag
- * WIDTH    is how many columns contain tags
- * MAPPER   is how tags should be mapped to after being consumed by BLT
- *           mapped tags only exist dynamically in BLT
- * AS       is how the (possibly artificial) sheet should be named by BLT
- *
- * Example:
- *   | Identity | A2 | 2 |
- * In the sheet "Identity" there is a table of width 2 storing tags.
- *    The first tag in this table is at A2
- */
+import {getSheetsTags} from "./getTagSheets";
 
 const {asyncCached, setCache} = makeCache<Tags>();
-
-const rowIsRange = ([, topLeft, width]: string[]): boolean =>
-	topLeft && width && /^[A-Z]+[0-9]+$/.test(topLeft) && /^[0-9]+$/.test(width);
-
-const rowToSheetDescriptor = ([sheet, topLeft, width, cwColumn, userMapper, as]: string[]): TagSheetDescriptor => {
-	// `left` is a column, for example "B"
-	const left = topLeft.match(/^[A-Z]+/)[0];
-	// `top` is a row, for example "4"
-	const top = topLeft.match(/[0-9]+$/)[0];
-	// `right` is the right most column with tags if there are `width` columns of tags
-	// for example, `left` = "B", `width` = 2, `right` = "C"
-	const right = incrementColumnBy(left, Number(width) - 1);
-	const range: Range = `${sheet}!${topLeft}:${right}`;
-	const cwRange: Range = cwColumn ? `${sheet}!${cwColumn}${top}:${cwColumn}` : undefined;
-	const mapper: TagMapper = (userMapper ?? "").includes("$TAG") ? (userMapper as TagMapper) : "$TAG";
-	return {range, mapper, cwRange, height: Number(width), name: as ?? sheet};
-};
-
-const getSheetDescriptors = async (): Promise<TagSheetDescriptor[]> => {
-	const range = Sheets.createRange(META_TAG_SHEET, "A", "F");
-	const response = await Sheets.readRanges(await getSheetId(), [range]);
-	return response?.[0].values.filter(rowIsRange).map(rowToSheetDescriptor) ?? [];
-};
-
-const extractRanges = (ranges: TagSheetDescriptor[]): Set<Range> =>
-	ranges.reduce(
-		(acc, {cwRange, range}) => (cwRange ? acc.add(cwRange).add(range) : acc.add(range)),
-		new Set<Range>()
-	);
-
-const nameResponses = (ranges: Range[], response: ValueRange[] | null): Map<Range, Values> => {
-	const groupedResponses = new Map();
-	response?.forEach((valueRange, index) => groupedResponses.set(ranges[index], valueRange?.values));
-	return groupedResponses;
-};
-
-const annotateWithContentWarnings = (tags: string[][], contentWarnings: Values | undefined): WarnedTag[][] =>
-	tags.map((row, rowIndex) => row.map((cell) => ({tag: cell, warning: !!contentWarnings?.values?.[rowIndex]?.[0]})));
-
-const toTagSheet =
-	(namedResponses: Map<Range, Values>) =>
-	(descriptor: TagSheetDescriptor): RawTagSheet => {
-		const tags = namedResponses.get(descriptor.range);
-		const mappedTags = mapTags(tags, descriptor.mapper);
-		const contentWarnings = namedResponses.get(descriptor.cwRange);
-		const values = annotateWithContentWarnings(mappedTags, contentWarnings);
-		return {...descriptor, values};
-	};
-
-const getSheetsTags = async (): Promise<RawTagSheet[]> => {
-	const mappedRanges = await getSheetDescriptors();
-	const ranges = [...extractRanges(mappedRanges)]; // We might have duplicate ranges, so we use a set when extracting
-	const response = await Sheets.readRanges(await getSheetId(), ranges);
-	const namedResponses = nameResponses(ranges, response);
-	return mappedRanges.map(toTagSheet(namedResponses));
-};
-
-const mapTags = (values: Values | undefined, mapper: TagMapper): string[][] => {
-	return values?.map((row) => row.map((value) => mapper.replaceAll("$TAG", value))) ?? [];
-};
 
 const getTagTrees = async ({noCache}: TagSearchOptions = {noCache: false}) => {
 	const implementation = async () => parseTags(await getSheetsTags());

--- a/src/ts/content/adapters/tags/parseTags.ts
+++ b/src/ts/content/adapters/tags/parseTags.ts
@@ -13,12 +13,11 @@ const parseRows = ({rows, fromRow, depth, nodes, parent}: ParserOptions): number
 	while (row < rows.length) {
 		const {tag, warning} = rows[row][depth] ?? {};
 		if (tag) {
-			const trimmedTag = tag.trim();
-			const node = {name: trimmedTag, parent, warning, children: [], height: parent.height - 1};
+			const node = {name: tag, parent, warning, children: [], height: parent.height - 1};
 			parent.children.push(node);
 			// TODO if nodes already contains this tag, we need to emit a warning somehow!!! see #214
 			// Keys in the tag nodes map are lowercase for ez lookup later
-			nodes.set(trimmedTag.toLowerCase(), node);
+			nodes.set(tag.toLowerCase(), node);
 			row = parseRows({rows, fromRow: row + 1, depth: depth + 1, nodes, parent: node});
 		} else {
 			break;


### PR DESCRIPTION
resolves #261 

OK now after everyone has this, let's image we update how the Tag Index is formatted
- If the Tag Index is behind the Extension, it'll be fine because we'll support all the old formats as well
- If the Extension is behind the sheet, we don't try to parse it, and tell the user that they need to update the extension

If we decide to go with this implementation, the following algorithm can _never_ change:
1. Read the _entire_ Tag Index Index sheet.
2. Read the first row looking for the keyword `#format`
3. Take the following cell and assume that's the format
4. If nothing is found, assume the format is `aaliyah`

One possible alternative that _could_ save on bandwidth in future formats, but is _always_ worse with present formats:
1. Read Tag Index A1:B1
2. Check if there is `#format` in A1
3. Take B1 as format if so
4. If nothing found, assume the format is `aaliyah`
