### PR TITLE
Yield after case had inappropriately narrow types

### DIFF
--- a/src/ts/common/util/match.ts
+++ b/src/ts/common/util/match.ts
@@ -3,7 +3,7 @@ type Match<On, Out> = {
 		predicate: (value: On) => value is Sub,
 		yields: (value: Sub) => Opt
 	): Match<On, Out | Opt> & Yield<void>;
-	case<Opt>(predicate: (value: On) => true, yields: (value: On) => Opt): Yield<Opt>;
+	case<Opt>(predicate: (value: On) => true, yields: (value: On) => Opt): Yield<Out | Opt>;
 	case<Opt>(predicate: (value: On) => boolean, yields: (value: On) => Opt): Match<On, Out | Opt> & Yield<void>;
 	default<Opt>(yields: (value: On) => Opt): Yield<Out | Opt>;
 };

--- a/test/util/match.spec.ts
+++ b/test/util/match.spec.ts
@@ -150,4 +150,30 @@ const typeTests = () => {
 	abc satisfies "a" | "b" | "c";
 	// @ts-expect-error yield types should be preserved when actually yielding
 	abc satisfies "a";
+
+	// Yield after an always true case should behave like yield after a default
+	const someCase = match(foo)
+		.case(
+			(): boolean => Math.random() < 0.5,
+			() => "case 1" as const
+		)
+		.case(
+			(): true => true,
+			() => "case 2" as const
+		)
+		.yield();
+	if (someCase === "case 1") {
+		// 50% chance this happens
+	}
+	match(foo)
+		.case(
+			(): boolean => Math.random() < 0.5,
+			() => "case 1" as const
+		)
+		.case(
+			(): true => true,
+			() => "case 2" as const
+		)
+		// @ts-expect-error yield after a always true case should behave like a default
+		.yield() satisfies "case 2";
 };


### PR DESCRIPTION
fixes a silly type level bug.

don't need to push a new release, because this isn't a runtime problem