### PR TITLE
Use replaceState over pushState

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
 			let md = "README.md";
 			if (window.location.hash.length > 1) {
 				const path = window.location.hash.replace("#", "");
-				history.pushState({page: 1}, "Redirecting", path);
+				history.replaceState({path}, "Redirecting", path);
 				md = path.replace(/\.pretty/, "");
 			}
 


### PR DESCRIPTION
This is a website bug.

Every time you go to a page (even on refresh or back/forward navgation), it _adds_ a state to the history. It really only needs to do a replace to satisfy the redirect black magic the site does.